### PR TITLE
Generate maps of applicant locations for each competition

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,13 @@ username = "[USERNAME]"
 api_key = "[API KEY]"
 ```
 
+# Run script to generate map
+The lfc_script.py file uses command line arguments to generate maps showing applicant locations based on competition.  
+In the file directory run  
+```console
+python lfc_script.py [Competition key] [Color of map marker]  
+```
 
+The competition name keys should be one of the following: LLIA2020, LFC100Change2020, LFC100Change2017, EO2020, RacialEquity2030, Climate2030, ECW2020, LoneStar    
+
+The colors can be one of the following: blue, red, black, purple  (For the full documentation of using colors in Folium, check https://python-visualization.github.io/folium/modules.html)  

--- a/src/lfc_scripts.py
+++ b/src/lfc_scripts.py
@@ -17,10 +17,9 @@ def main():
 
     #Setup Map
     mapit = folium.Map(location=[48, -102], zoom_start=6)
-    loc = 'Corpus Christi'
     title_html = '''
                  <h3 align="center" style="font-size:16px"><b>Applicant Location Maps</b></h3>
-                 '''.format(loc)
+                 '''.format()
 
     #Retrieve proposal ids from competition
     response = site.api(
@@ -34,14 +33,17 @@ def main():
 
     feature_group = FeatureGroup(competition)
     for coord in locations:
-        folium.CircleMarker(location=[coord[0], coord[1]], fill_color=color, radius=7, color = color, opacity = 0.5, weight = 1).add_to(feature_group)
+        folium.CircleMarker(location=[coord[0], coord[1]],
+                            fill_color=color, radius=7,
+                            color = color, opacity = 0.5,
+                            weight = 1).add_to(feature_group)
     feature_group.add_to(mapit)
     LayerControl().add_to(mapit)
     mapit.get_root().html.add_child(folium.Element(title_html))
     mapit.save('applicant_locations_' + competition + '.html')
 
 def extract_locations(proposal_ids, competition):
-    #Failed geolocation spreadsheet
+
     error_list = []
     # Extract organization locations
     locations = []
@@ -54,7 +56,7 @@ def extract_locations(proposal_ids, competition):
         )
         response['result']
         org_location = geolocator.geocode(
-            concat_org_location(response['result']))  # Convert named address to latlong pair
+            concat_org_location(response['result'])) # Convert named address to latlong pair
         try:
             coordinate_pair = (org_location.latitude, org_location.longitude)
             locations.append(coordinate_pair)

--- a/src/lfc_scripts.py
+++ b/src/lfc_scripts.py
@@ -2,31 +2,36 @@ import mwclient
 import config
 from geopy.geocoders import Nominatim
 import folium
+from folium import FeatureGroup, LayerControl, Map, Marker
 
-COMPETITION_NAME = "LFC100Change2020"
+
+competitions = ["LLIIA2020", "LFC100Change2020", "LFC100Change2017", "EO2020", "RacialEquity2030", "Climate2030", "ECW2020", "LoneStar2020"]
+
 site = mwclient.Site('torque.leverforchange.org/', 'GlobalView/', scheme="https")
 site.login(config.username, config.api_key)
 geolocator = Nominatim(user_agent = "map")
 
 def main():
-    response = site.api(
-        'torquedataconnect',
-        format='json',
-        path='/competitions/' + COMPETITION_NAME + '/proposals'
-    )
-    proposal_ids = response["result"]
-
-    locations = extract_locations(proposal_ids)
-    generate_map(locations)
-
-def generate_map(locations):
-    # Plot latlong points
     mapit = folium.Map(location=[48, -102], zoom_start=6)
-    for coord in locations:
-        folium.Marker(location=[coord[0], coord[1]], fill_color='#43d9de', radius=4).add_to(mapit)
+    for competition in competitions:
+        response = site.api(
+            'torquedataconnect',
+            format='json',
+            path='/competitions/' + competition + '/proposals'
+        )
+        proposal_ids = response["result"]
+
+        locations = extract_locations(proposal_ids, competition)
+
+        feature_group = FeatureGroup(competition)
+        for coord in locations:
+            folium.Marker(location=[coord[0], coord[1]], fill_color='#43d9de', radius=4).add_to(feature_group)
+        feature_group.add_to(mapit)
+    LayerControl().add_to(mapit)
     mapit.save('map1.html')
 
-def extract_locations(proposal_ids):
+
+def extract_locations(proposal_ids, competition):
     # Extract organization locations
     locations = []
     for id in proposal_ids:
@@ -34,28 +39,36 @@ def extract_locations(proposal_ids):
         response = site.api(
             'torquedataconnect',
             format='json',
-            path='/competitions/' + COMPETITION_NAME + '/proposals' + '/' + id
+            path='/competitions/' + competition + '/proposals' + '/' + id
         )
         response['result']
         org_location = geolocator.geocode(
             concat_org_location(response['result']))  # Convert named address to latlong pair
         try:
             coordinate_pair = (org_location.latitude, org_location.longitude)
+            locations.append(coordinate_pair)
         except:
             print('error, not a location')
-        locations.append(coordinate_pair)
+
     return locations
 
 def concat_org_location(proposal):
 
     org_location = []
     for key, value in proposal.items():
-        if key == "Org Locality/ District/ County":
+
+        if key == "City":
             org_location.append(value)
-        if key == "Org State/Province":
+        if key == "Org Country" or key == "Country" or key == "Nation":
             org_location.append(value)
-        if key == "Org Country":
+        """
+        if key == "Street Address":
             org_location.append(value)
+        if "Locality" in key or "District" in key or "County" in key:
+            org_location.append(value)
+        if "State" in key or "Province" in key:
+            org_location.append(value)
+        """
     return org_location
 
 if __name__ == "__main__":

--- a/src/lfc_scripts.py
+++ b/src/lfc_scripts.py
@@ -3,11 +3,12 @@ import config
 from geopy.geocoders import Nominatim
 import folium
 
-def main():
-    COMPETITION_NAME = "LoneStar2020"
-    site = mwclient.Site('torque.leverforchange.org/', 'GlobalView/', scheme="https")
-    site.login(config.username, config.api_key)
+COMPETITION_NAME = "LFC100Change2020"
+site = mwclient.Site('torque.leverforchange.org/', 'GlobalView/', scheme="https")
+site.login(config.username, config.api_key)
+geolocator = Nominatim(user_agent = "map")
 
+def main():
     response = site.api(
         'torquedataconnect',
         format='json',
@@ -15,8 +16,17 @@ def main():
     )
     proposal_ids = response["result"]
 
-    geolocator = Nominatim(user_agent = "map")
+    locations = extract_locations(proposal_ids)
+    generate_map(locations)
 
+def generate_map(locations):
+    # Plot latlong points
+    mapit = folium.Map(location=[48, -102], zoom_start=6)
+    for coord in locations:
+        folium.Marker(location=[coord[0], coord[1]], fill_color='#43d9de', radius=4).add_to(mapit)
+    mapit.save('map1.html')
+
+def extract_locations(proposal_ids):
     # Extract organization locations
     locations = []
     for id in proposal_ids:
@@ -27,18 +37,14 @@ def main():
             path='/competitions/' + COMPETITION_NAME + '/proposals' + '/' + id
         )
         response['result']
-        org_location = geolocator.geocode(concat_org_location(response['result'])) # Convert named address to latlong pair
+        org_location = geolocator.geocode(
+            concat_org_location(response['result']))  # Convert named address to latlong pair
         try:
             coordinate_pair = (org_location.latitude, org_location.longitude)
         except:
             print('error, not a location')
         locations.append(coordinate_pair)
-
-    # Plot latlong points
-    mapit = folium.Map(location = [48, -102], zoom_start=6)
-    for coord in locations:
-        folium.Marker(location=[coord[0], coord[1]], fill_color='#43d9de', radius=4).add_to(mapit)
-    mapit.save('map.html')
+    return locations
 
 def concat_org_location(proposal):
 

--- a/src/lfc_scripts.py
+++ b/src/lfc_scripts.py
@@ -6,14 +6,15 @@ from folium import FeatureGroup, LayerControl, Map, Marker
 
 
 competitions = ["LLIIA2020", "LFC100Change2020", "LFC100Change2017", "EO2020", "RacialEquity2030", "Climate2030", "ECW2020", "LoneStar2020"]
-
 site = mwclient.Site('torque.leverforchange.org/', 'GlobalView/', scheme="https")
 site.login(config.username, config.api_key)
 geolocator = Nominatim(user_agent = "map")
 
 def main():
     mapit = folium.Map(location=[48, -102], zoom_start=6)
-    for competition in competitions:
+    colors = ["red", "blue", "gray", "green", "pink", "purple"]
+    for i in range(0, len(competitions)):
+        competition = competitions[i]
         response = site.api(
             'torquedataconnect',
             format='json',
@@ -25,7 +26,7 @@ def main():
 
         feature_group = FeatureGroup(competition)
         for coord in locations:
-            folium.Marker(location=[coord[0], coord[1]], fill_color='#43d9de', radius=4).add_to(feature_group)
+            folium.CircleMarker(location=[coord[0], coord[1]], fill_color='#43d9de', radius=10, color = colors[i], opacity = 0.5   ).add_to(feature_group)
         feature_group.add_to(mapit)
     LayerControl().add_to(mapit)
     mapit.save('map1.html')


### PR DESCRIPTION
This pull request generates maps of applicant locations and incorporates command line arguments for the user to decide which competition map they want as output. There is an additional error spreadsheet incorporated to show which proposal locations failed to successfully geolocate.

Map has also been styled as per preliminary feedback from @slifty . 

Resolves #8 